### PR TITLE
fix: config function item param can´t be optional

### DIFF
--- a/core/support/config.php
+++ b/core/support/config.php
@@ -3,11 +3,11 @@
 /**
  * Get environment variable value
  *
- * @param string|null $item config item wanted (optional)
+ * @param string $item config item wanted
  * @param mixed $default default value if item isn't set (optional)
  *
  * @return mixed Value of config
  */
-function config(string $item = null, mixed $default = null): mixed {
+function config(string $item, mixed $default = null): mixed {
     return $_ENV[$item] ?? $default;
 }


### PR DESCRIPTION
## Description
Hot fix for last implementation.

## Checklist
Check or add the boxes that apply to this pull request:
- [x] Documentation has been updated.
- [x] All merge conflicts have been resolved.
- [x] The pull request is targeted to the correct branch.

## Proposed Changes
Config function item parameter can´t be optional.

- [x] Turn config function item parameter required
