### PR TITLE
Corrige link para documentação

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -212,7 +212,7 @@
         </div>
         <div class="content">
           <a
-            href="https://edigar.github.io/noobframework"
+            href="https://edigar.github.io/noobframework-doc/"
             target="_blank"
             rel="noreferrer"
             class="card"


### PR DESCRIPTION
**Atualização de URL para a documentação do framework no `index.html`**

**Descrição:**  
- Atualizei uma URL no arquivo `index.html`, localizada na linha 215.  
- A nova URL agora aponta corretamente para a documentação oficial do framework.

**Detalhes da alteração:**  
- Linha 215: Substituição da URL antiga pela nova, que direciona para a página da documentação do framework.

![image](https://github.com/user-attachments/assets/4d667240-8a4c-4784-b48b-4c1cb3ae2bca)
